### PR TITLE
[#162974885] Allow user to throttle job concurrency via sidekiq-throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Rails.application.routes.default_url_options ||= {}
 Rails.application.routes.default_url_options[:host] = ENV["HOST"]
 ```
 
+Setup [sidekiq-throttled](https://github.com/sensortower/sidekiq-throttled) by adding the following to the rails app sidekiq.rb initializer:
+
+```ruby
+require "sidekiq/throttled"
+Sidekiq::Throttled.setup!
+```
+
 # Usage
 
 In your controller where you want a `create` action:
@@ -45,6 +52,18 @@ class CreateSomething
       something.errors.messages
     end
   end
+end
+```
+
+Use the throttle option to allow limited conccurency given a value that can be fetched from job.params
+
+```ruby
+# Given a job: #<Asyncapi::Server::Job id: 1, status: nil, callback_url: "callback_url", class_name: "CreateSomething", params: {"storage_facility"=>{"external_id"=>"storage-facility-external-id"}, secret: "sekret">,
+# a user can set concurrency for jobs having an external_id of "storage-facility-external-id"
+
+# some_controller.rb
+class SomeController < ApplicationController
+  async :create, CreateSomething, { keys: ["storage_facility", "external_id"], concurrency: 1 }
 end
 ```
 

--- a/app/workers/asyncapi/server/job_worker.rb
+++ b/app/workers/asyncapi/server/job_worker.rb
@@ -45,7 +45,9 @@ module Asyncapi::Server
 
     def fetch_key(job_id, throttled)
       job = Job.find(job_id)
-      job.params.dig(*throttled["keys"]).to_s
+      key = job.params.dig(*throttled["keys"]).to_s
+
+      (key.nil?) ? job_id.to_s : key
     end
 
     def report_job_status(job, job_message)

--- a/app/workers/asyncapi/server/job_worker.rb
+++ b/app/workers/asyncapi/server/job_worker.rb
@@ -2,10 +2,20 @@ module Asyncapi::Server
   class JobWorker
 
     include Sidekiq::Worker
+    include Sidekiq::Throttled::Worker
+
     sidekiq_options retry: false
     MAX_RETRIES = 2
 
-    def perform(job_id, retries=0)
+    sidekiq_throttle({
+      # If throttled, set the concurrency to `concurrency` along with user defined job.parameter key
+      :concurrency => {
+        :limit      => ->(throttled) { (!!throttled) ? throttled["concurrency"].to_i : 10 },
+        :key_suffix => ->(job_id, throttled) { (!!throttled) ? fetch_key(job_id, throttled) : job_id }
+      }
+    })
+
+    def perform(job_id, retries=0, throttled)
       job = Job.find(job_id)
       runner_class = job.class_name.constantize
 
@@ -32,6 +42,11 @@ module Asyncapi::Server
     end
 
     private
+
+    def fetch_key(job_id, throttled)
+      job = Job.find(job_id)
+      job.params.dig(*throttled["keys"]).to_s
+    end
 
     def report_job_status(job, job_message)
       Typhoeus.put(

--- a/asyncapi_server.gemspec
+++ b/asyncapi_server.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "active_model_serializers", "~> 0.9.0"
   s.add_dependency "typhoeus"
   s.add_dependency "sidekiq"
+  s.add_dependency "sidekiq-throttled"
   s.add_dependency "responders"
   s.add_dependency "ar_after_transaction"
 

--- a/lib/asyncapi/server/rails_ext/controller.rb
+++ b/lib/asyncapi/server/rails_ext/controller.rb
@@ -6,11 +6,11 @@ module Asyncapi
         extend ActiveSupport::Concern
 
         module ClassMethods
-          def async(method_name, klass)
+          def async(method_name, klass, throttled=false)
             define_method(method_name) do
               job = Job.create(job_params_with(klass.name))
               ActiveRecord::Base.after_transaction do
-                JobWorker.perform_async(job.id)
+                JobWorker.perform_async(job.id, throttled)
               end
               serializer = JobSerializer.new(job)
               render json: serializer


### PR DESCRIPTION
Using [sidekiq-throttle](https://github.com/sensortower/sidekiq-throttled), allow users to configure job concurrency when a job meets the user's pre-defined filter.

```ruby
# some_controller.rb
class SomeController < ApplicationController
  async :create, CreateSomething, { keys: ["storage_facility", "external_id"], concurrency: 1 }
end
```

Refer to README.md for more information.