### PR TITLE
Decouple job status notification from job worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.0] - 2021-03-24
+### Added [#14](http://github.com/G5/asyncapi-server/pull/10)
+- Decouple job status notification from JobWorker
+
 ## [1.2.0] - 2019-05-29
 ### Added [#10](http://github.com/G5/asyncapi-server/pull/10)
 - Make gem Rails 5 compatible

--- a/app/serializers/asyncapi/server/job_serializer.rb
+++ b/app/serializers/asyncapi/server/job_serializer.rb
@@ -2,7 +2,7 @@ module Asyncapi
   module Server
     class JobSerializer < ActiveModel::Serializer
 
-      attributes :id, :url, :secret
+      attributes :id, :status, :url, :secret
 
     end
   end

--- a/app/workers/asyncapi/server/job_status_notifier_worker.rb
+++ b/app/workers/asyncapi/server/job_status_notifier_worker.rb
@@ -1,0 +1,51 @@
+module Asyncapi::Server
+  class JobStatusNotifierWorker
+
+    include Sidekiq::Worker
+    sidekiq_options retry: false
+    MAX_RETRIES = 2
+
+    def perform(job_id, job_message, retries=0)
+      job = Job.find(job_id)
+
+      report_job_status(job, job_message)
+
+      unless @response.code == 200
+        if retries <= MAX_RETRIES
+          JobStatusNotifierWorker.perform_async(job_id, job_message, retries+1)
+
+          raise "Attempt##{retries} to notify #{job.callback_url} failed."
+        else
+          raise format_error(job)
+        end
+      end
+    end
+
+    private
+
+    def report_job_status(job, job_message)
+      @response ||= Typhoeus.put(
+        job.callback_url,
+        body: {
+          job: {
+            status: job.status,
+            message: job_message,
+            secret: job.secret,
+          }
+        }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          Accept: "application/json"
+        }
+      )
+    end
+
+    def format_error(job)
+      [
+        "Something went wrong while poking #{job.callback_url}",
+        "HTTP Status: #{@response.code}",
+        "HTTP Body: #{@response.body}",
+      ].join("\n")
+    end
+  end
+end

--- a/app/workers/asyncapi/server/job_status_notifier_worker.rb
+++ b/app/workers/asyncapi/server/job_status_notifier_worker.rb
@@ -12,7 +12,7 @@ module Asyncapi::Server
 
       unless @response.code == 200
         if retries <= MAX_RETRIES
-          JobStatusNotifierWorker.perform_async(job_id, job_message, retries+1)
+          @jid = JobStatusNotifierWorker.perform_async(job_id, job_message, retries+1)
 
           raise format_error("Attempt##{retries} to notify #{@job.callback_url} failed.")
         else
@@ -44,8 +44,9 @@ module Asyncapi::Server
       [
         error,
         "JobID: #{@job.id}",
+        "Next Attempt: #{@jid}",
         "HTTP Status: #{@response.code}",
-        "HTTP Body: #{@response.body}",
+        "HTTP Response: #{@response.inspect}",
       ].join("\n")
     end
   end

--- a/app/workers/asyncapi/server/job_status_notifier_worker.rb
+++ b/app/workers/asyncapi/server/job_status_notifier_worker.rb
@@ -13,8 +13,6 @@ module Asyncapi::Server
       unless @response.code == 200
         if retries <= MAX_RETRIES
           @jid = JobStatusNotifierWorker.perform_async(job_id, job_message, retries+1)
-
-          raise format_error("Attempt##{retries} to notify #{@job.callback_url} failed.")
         else
           raise format_error("Something went wrong while poking #{@job.callback_url}")
         end

--- a/app/workers/asyncapi/server/job_worker.rb
+++ b/app/workers/asyncapi/server/job_worker.rb
@@ -34,21 +34,7 @@ module Asyncapi::Server
     private
 
     def report_job_status(job, job_message)
-      Typhoeus.put(
-        job.callback_url,
-        body: {
-          job: {
-            status: job.status,
-            message: job_message,
-            secret: job.secret,
-          }
-        }.to_json,
-        headers: {
-          "Content-Type" => "application/json",
-          Accept: "application/json"
-        }
-      )
+      JobStatusNotifierWorker.perform_async(job.id, job_message)
     end
-
   end
 end

--- a/lib/asyncapi/server/version.rb
+++ b/lib/asyncapi/server/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Server
-    VERSION = "1.2.0"
+    VERSION = "1.3.0-alpha.01"
   end
 end

--- a/lib/asyncapi/server/version.rb
+++ b/lib/asyncapi/server/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Server
-    VERSION = "1.3.0-alpha.02"
+    VERSION = "1.3.0-alpha.03"
   end
 end

--- a/lib/asyncapi/server/version.rb
+++ b/lib/asyncapi/server/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Server
-    VERSION = "1.3.0-alpha.03"
+    VERSION = "1.3.0-alpha.04"
   end
 end

--- a/lib/asyncapi/server/version.rb
+++ b/lib/asyncapi/server/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Server
-    VERSION = "1.3.0-alpha.01"
+    VERSION = "1.3.0-alpha.02"
   end
 end

--- a/lib/asyncapi/server/version.rb
+++ b/lib/asyncapi/server/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Server
-    VERSION = "1.3.0-alpha.04"
+    VERSION = "1.3.0-alpha.05"
   end
 end

--- a/spec/serializers/job_serializer_spec.rb
+++ b/spec/serializers/job_serializer_spec.rb
@@ -8,6 +8,7 @@ module Asyncapi::Server
     subject(:serialized_hash) { serializer.attributes }
 
     its([:id]) { is_expected.to eq job.id }
+    its([:status]) { is_expected.to eq job.status }
 
     it "has a url" do
       allow(job).to receive(:url).and_return("url")

--- a/spec/workers/job_status_notifier_spec.rb
+++ b/spec/workers/job_status_notifier_spec.rb
@@ -80,6 +80,14 @@ module Asyncapi
 
           context "when final attempt still fails" do
             let(:retries) { 1 }
+            let(:expected_error_message) do
+              [
+                "Attempt##{retries} to notify #{job.callback_url} failed.",
+                "JobID: #{job.id}",
+                "HTTP Status: #{response.code}",
+                "HTTP Body: #{response.body}",
+              ].join("\n")
+            end
 
             it "raises attempt failure and retries" do
               expect(JobStatusNotifierWorker).to(
@@ -87,7 +95,7 @@ module Asyncapi
               )
 
               expect { described_class.new.perform(job.id, message, retries) }.to(
-                raise_error "Attempt##{retries} to notify #{job.callback_url} failed."
+                raise_error expected_error_message
               )
             end
           end
@@ -96,6 +104,7 @@ module Asyncapi
             let(:expected_error_message) do
               [
                 "Something went wrong while poking #{job.callback_url}",
+                "JobID: #{job.id}",
                 "HTTP Status: #{response.code}",
                 "HTTP Body: #{response.body}",
               ].join("\n")

--- a/spec/workers/job_status_notifier_spec.rb
+++ b/spec/workers/job_status_notifier_spec.rb
@@ -52,7 +52,7 @@ module Asyncapi
           described_class.new.perform(job.id, message)
         end
 
-        context "an error occurred while notifying callback_url" do
+        context "when an error occurred while notifying callback_url" do
           let(:code) { 404 }
           let(:body) do
             {
@@ -78,7 +78,7 @@ module Asyncapi
             ).and_return(response)
           end
 
-          context "when final attempt still fails" do
+          context "when initial attempt fails" do
             let(:retries) { 1 }
             let(:expected_error_message) do
               [

--- a/spec/workers/job_status_notifier_spec.rb
+++ b/spec/workers/job_status_notifier_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+
+module Asyncapi
+  module Server
+    describe JobStatusNotifierWorker do
+
+      it "does not retry" do
+        expect(described_class.sidekiq_options_hash['retry']).to be false
+      end
+
+      describe "#perform" do
+        let(:message) { nil }
+        let(:code) { 200 }
+        let(:body) do
+          {
+            id: 12345,
+            server_job_url: "server_job_url",
+            status: "success",
+          }
+        end
+        let(:response) do
+          double(:response_double,
+            code: code,
+            body: body,
+          )
+        end
+        let(:job) do
+          create(:asyncapi_server_job, {
+            class_name: "Runner",
+            callback_url: "client_job_url",
+            status: :success,
+            secret: "secret",
+          })
+        end
+
+        it "notifies a job's callback_url with the job status" do
+          expect(Typhoeus).to receive(:put).with(
+            job.callback_url,
+            body: {
+              job: {
+                status: job.status,
+                message: message,
+                secret: job.secret,
+              }
+            }.to_json,
+            headers: {
+              "Content-Type" => "application/json",
+              Accept: "application/json"
+            }
+          ).and_return(response)
+
+          described_class.new.perform(job.id, message)
+        end
+
+        context "an error occurred while notifying callback_url" do
+          let(:code) { 404 }
+          let(:body) do
+            {
+              error: "404",
+              status: "Not Found",
+            }
+          end
+
+          before do
+            expect(Typhoeus).to receive(:put).with(
+              job.callback_url,
+              body: {
+                job: {
+                  status: job.status,
+                  message: message,
+                  secret: job.secret,
+                }
+              }.to_json,
+              headers: {
+                "Content-Type" => "application/json",
+                Accept: "application/json"
+              }
+            ).and_return(response)
+          end
+
+          context "when final attempt still fails" do
+            let(:retries) { 1 }
+
+            it "raises attempt failure and retries" do
+              expect(JobStatusNotifierWorker).to(
+                receive(:perform_async).with(job.id, message, retries+1)
+              )
+
+              expect { described_class.new.perform(job.id, message, retries) }.to(
+                raise_error "Attempt##{retries} to notify #{job.callback_url} failed."
+              )
+            end
+          end
+
+          context "when final attempt still fails" do
+            let(:expected_error_message) do
+              [
+                "Something went wrong while poking #{job.callback_url}",
+                "HTTP Status: #{response.code}",
+                "HTTP Body: #{response.body}",
+              ].join("\n")
+            end
+
+            it "raises error if no progress is made after MAX_RETRIES attempts" do
+              expect { described_class.new.perform(job.id, message, 3) }.to(
+                raise_error expected_error_message
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/workers/job_status_notifier_worker_spec.rb
+++ b/spec/workers/job_status_notifier_worker_spec.rb
@@ -81,24 +81,13 @@ module Asyncapi
 
           context "when initial attempt fails" do
             let(:retries) { 1 }
-            let(:expected_error_message) do
-              [
-                "Attempt##{retries} to notify #{job.callback_url} failed.",
-                "JobID: #{job.id}",
-                "Next Attempt: #{jid}",
-                "HTTP Status: #{response.code}",
-                "HTTP Response: #{response.inspect}",
-              ].join("\n")
-            end
 
             it "raises attempt failure and retries" do
               expect(JobStatusNotifierWorker).to(
                 receive(:perform_async).with(job.id, message, retries+1).and_return(jid)
               )
 
-              expect { described_class.new.perform(job.id, message, retries) }.to(
-                raise_error expected_error_message
-              )
+              expect { described_class.new.perform(job.id, message, retries) }.not_to raise_error
             end
           end
 

--- a/spec/workers/job_status_notifier_worker_spec.rb
+++ b/spec/workers/job_status_notifier_worker_spec.rb
@@ -60,6 +60,7 @@ module Asyncapi
               status: "Not Found",
             }
           end
+          let(:jid) { "abcde12345" }
 
           before do
             expect(Typhoeus).to receive(:put).with(
@@ -84,14 +85,15 @@ module Asyncapi
               [
                 "Attempt##{retries} to notify #{job.callback_url} failed.",
                 "JobID: #{job.id}",
+                "Next Attempt: #{jid}",
                 "HTTP Status: #{response.code}",
-                "HTTP Body: #{response.body}",
+                "HTTP Response: #{response.inspect}",
               ].join("\n")
             end
 
             it "raises attempt failure and retries" do
               expect(JobStatusNotifierWorker).to(
-                receive(:perform_async).with(job.id, message, retries+1)
+                receive(:perform_async).with(job.id, message, retries+1).and_return(jid)
               )
 
               expect { described_class.new.perform(job.id, message, retries) }.to(
@@ -105,8 +107,9 @@ module Asyncapi
               [
                 "Something went wrong while poking #{job.callback_url}",
                 "JobID: #{job.id}",
+                "Next Attempt: ",
                 "HTTP Status: #{response.code}",
-                "HTTP Body: #{response.body}",
+                "HTTP Response: #{response.inspect}",
               ].join("\n")
             end
 


### PR DESCRIPTION
- Allows **JobStatusNotifierWorker** to retry when its attempt to notify the **callback_url** fails for any reason. 
- Raises an appropriate error to help investigate the issue at a later date